### PR TITLE
Support searching by monster CR

### DIFF
--- a/src/beholder.go
+++ b/src/beholder.go
@@ -102,7 +102,7 @@ func (a *App) Query(query string) []SearchResult {
 	qm := NewQueryMatcher(query)
 	results := make([]SearchResult, 0, queryLimit)
 	for _, e := range a.entities {
-		m := qm.Match(e.GetName())
+		m := qm.MatchName(e.GetName())
 		if m.Matched {
 			results = append(results, &scoredEntity{
 				e,

--- a/src/beholder.go
+++ b/src/beholder.go
@@ -102,7 +102,7 @@ func (a *App) Query(query string) []SearchResult {
 	qm := NewQueryMatcher(query)
 	results := make([]SearchResult, 0, queryLimit)
 	for _, e := range a.entities {
-		m := qm.MatchName(e.GetName())
+		m := qm.Match(e)
 		if m.Matched {
 			results = append(results, &scoredEntity{
 				e,

--- a/src/queries-cr.go
+++ b/src/queries-cr.go
@@ -1,0 +1,27 @@
+package beholder
+
+type ChallengeRatingQuery struct {
+	cr string
+}
+
+func NewChallengeRatingQuery(cr string) *ChallengeRatingQuery {
+	return &ChallengeRatingQuery{cr}
+}
+
+func ExtractChallengeRatingQueries(query string) (remaining string, extracted []Query) {
+	return query, nil
+}
+
+func (q *ChallengeRatingQuery) Match(entity Entity) (result MatchResult) {
+	result = MatchResult{Matched: false, Score: 0, Sequences: nil}
+	if entity.GetKind() != MonsterEntity {
+		return
+	}
+
+	m := entity.(Monster)
+	if m.Challenge != q.cr {
+		return
+	}
+
+	return MatchResult{Matched: true, Score: 1, Sequences: nil}
+}

--- a/src/queries-cr.go
+++ b/src/queries-cr.go
@@ -1,5 +1,9 @@
 package beholder
 
+import (
+	"regexp"
+)
+
 type ChallengeRatingQuery struct {
 	cr string
 }
@@ -8,19 +12,30 @@ func NewChallengeRatingQuery(cr string) *ChallengeRatingQuery {
 	return &ChallengeRatingQuery{cr}
 }
 
+var crQueryRegex *regexp.Regexp = regexp.MustCompile(`(?i)\s*CR([0-9]+)\s*`)
+
 func ExtractChallengeRatingQueries(query string) (remaining string, extracted []Query) {
-	return query, nil
+	matches := crQueryRegex.FindAllStringSubmatch(query, -1)
+	if len(matches) > 0 {
+		extracted = make([]Query, 0, len(matches))
+		for _, match := range matches {
+			cr := match[1]
+			q := NewChallengeRatingQuery(cr)
+			extracted = append(extracted, q)
+		}
+	}
+	remaining = crQueryRegex.ReplaceAllLiteralString(query, "")
+	return
 }
 
-func (q *ChallengeRatingQuery) Match(entity Entity) (result MatchResult) {
-	result = MatchResult{Matched: false, Score: 0, Sequences: nil}
+func (q *ChallengeRatingQuery) Match(entity Entity) MatchResult {
 	if entity.GetKind() != MonsterEntity {
-		return
+		return MatchResult{Matched: false}
 	}
 
 	m := entity.(Monster)
 	if m.Challenge != q.cr {
-		return
+		return MatchResult{Matched: false}
 	}
 
 	return MatchResult{Matched: true, Score: 1, Sequences: nil}

--- a/src/queries-cr_test.go
+++ b/src/queries-cr_test.go
@@ -1,0 +1,47 @@
+package beholder
+
+import (
+	"fmt"
+	"testing"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func ShouldMatchMonster(actual any, expected ...any) string {
+	query := actual.(string)
+	monster := expected[0].(Monster)
+	if NewQueryMatcher(query).Match(monster).Matched {
+		return ""
+	}
+	return fmt.Sprintf("`%v` should match `%v`", query, monster)
+}
+
+func ShouldNotMatchMonster(actual any, expected ...any) string {
+	query := actual.(string)
+	monster := expected[0].(Monster)
+	if !NewQueryMatcher(query).Match(monster).Matched {
+		return ""
+	}
+	return fmt.Sprintf("`%v` should NOT match `%v`", query, monster)
+}
+
+func TestCRQueries(t *testing.T) {
+	Convey("ChallengeRatingQuery", t, func() {
+		Convey("should match a monster", func() {
+			So("cr2", ShouldMatchMonster, Monster{
+				Challenge: "2",
+			})
+		})
+
+		Convey("should cooperate with name filter", func() {
+			So("cr2 zom", ShouldMatchMonster, Monster{
+				Named:     Named{Name: "Zombie"},
+				Challenge: "2",
+			})
+			So("cr2 zom", ShouldNotMatchMonster, Monster{
+				Named:     Named{Name: "Kelpie"},
+				Challenge: "2",
+			})
+		})
+	})
+}

--- a/src/queries-registry.go
+++ b/src/queries-registry.go
@@ -1,0 +1,16 @@
+package beholder
+
+var queryExtractors = []func(string) (string, []Query){
+	ExtractChallengeRatingQueries,
+}
+
+func ExtractQueries(query string) (remaining string, extracted []Query) {
+	remaining = query
+	extracted = make([]Query, 0)
+	for _, extractor := range queryExtractors {
+		newRemaining, newExtracted := extractor(remaining)
+		remaining = newRemaining
+		extracted = append(extracted, newExtracted...)
+	}
+	return
+}

--- a/src/querymatcher.go
+++ b/src/querymatcher.go
@@ -5,13 +5,17 @@ import (
 	"unicode"
 )
 
+type Query interface {
+	Match(Entity) MatchResult
+}
+
 // QueryMatcher .
 type QueryMatcher struct {
+	queries    []Query
 	runes      []rune
 	upperRunes []rune
 }
 
-// MatchResult is the result of
 type MatchResult struct {
 	Matched   bool
 	Score     float32
@@ -32,14 +36,16 @@ func (s *MatchedSequence) length() int {
 
 // NewQueryMatcher .
 func NewQueryMatcher(query string) *QueryMatcher {
+	remainingQuery, extracted := ExtractQueries(query)
 	return &QueryMatcher{
-		[]rune(query),
-		[]rune(strings.ToUpper(query)),
+		extracted,
+		[]rune(remainingQuery),
+		[]rune(strings.ToUpper(remainingQuery)),
 	}
 }
 
 // Match .
-func (q *QueryMatcher) Match(value string) MatchResult {
+func (q *QueryMatcher) MatchName(value string) MatchResult {
 	runes := []rune(value)
 
 	sequences := make([]*MatchedSequence, 0, 8)
@@ -52,7 +58,7 @@ func (q *QueryMatcher) Match(value string) MatchResult {
 	inWord := true
 
 	j := 0
-	for i := 0; i < len(runes); i++ {
+	for i := range runes {
 
 		enteredWord := i == 0
 		if !unicode.IsLetter(runes[i]) {

--- a/src/querymatcher.go
+++ b/src/querymatcher.go
@@ -44,7 +44,38 @@ func NewQueryMatcher(query string) *QueryMatcher {
 	}
 }
 
-// Match .
+func (q *QueryMatcher) Match(entity Entity) MatchResult {
+	var result *MatchResult = nil
+
+	if len(q.runes) > 0 {
+		r := q.MatchName(entity.GetName())
+		result = &r
+	}
+
+	if len(q.queries) > 0 {
+		// If we have any Queries, the Entity must match ALL
+		// *in addition to* any provided text query
+		for _, query := range q.queries {
+			m := query.Match(entity)
+			if !m.Matched {
+				if result != nil {
+					result.Matched = false
+				}
+				break
+			} else if result == nil {
+				// If we don't have any result yet, then we did
+				// not have a query string. We found a match here
+				result = &m
+			}
+		}
+	}
+
+	if result == nil {
+		return MatchResult{Matched: false}
+	}
+	return *result
+}
+
 func (q *QueryMatcher) MatchName(value string) MatchResult {
 	runes := []rune(value)
 

--- a/src/querymatcher_test.go
+++ b/src/querymatcher_test.go
@@ -8,10 +8,10 @@ import (
 )
 
 func queryMatches(query, value string) bool {
-	return NewQueryMatcher(query).Match(value).Matched
+	return NewQueryMatcher(query).MatchName(value).Matched
 }
 
-func ShouldMatch(actual interface{}, expected ...interface{}) string {
+func ShouldMatch(actual any, expected ...any) string {
 	if queryMatches(actual.(string), expected[0].(string)) {
 		return ""
 	}
@@ -19,7 +19,7 @@ func ShouldMatch(actual interface{}, expected ...interface{}) string {
 	return fmt.Sprintf("`%v` should match `%v`", actual, expected[0])
 }
 
-func ShouldNotMatch(actual interface{}, expected ...interface{}) string {
+func ShouldNotMatch(actual any, expected ...any) string {
 	if !queryMatches(actual.(string), expected[0].(string)) {
 		return ""
 	}
@@ -32,7 +32,7 @@ type comparison struct {
 	fn    func(a, b float32) bool
 }
 
-func ShouldScore(actual interface{}, expected ...interface{}) string {
+func ShouldScore(actual any, expected ...any) string {
 	qm := NewQueryMatcher(actual.(string))
 	a := expected[0].(string)
 	compare := expected[1].(*comparison)
@@ -40,14 +40,14 @@ func ShouldScore(actual interface{}, expected ...interface{}) string {
 	bs := expected[2:]
 	bMatches := make([]MatchResult, 0, len(bs))
 
-	matchA := qm.Match(a)
+	matchA := qm.MatchName(a)
 
 	if !matchA.Matched {
 		return fmt.Sprintf("Expected Matcher('%s') to match: '%v'", actual, a)
 	}
 
 	for _, b := range bs {
-		m := qm.Match(b.(string))
+		m := qm.MatchName(b.(string))
 		if !m.Matched {
 			return fmt.Sprintf("Expected Matcher('%s') to match: '%v'", actual, b)
 		}
@@ -128,7 +128,7 @@ func TestQueryMatcher(t *testing.T) {
 		})
 
 		Convey("should have correct sequences", func() {
-			r := NewQueryMatcher("mcw").Match("Mass Cure Wounds")
+			r := NewQueryMatcher("mcw").MatchName("Mass Cure Wounds")
 			So(r.Sequences, ShouldHaveLength, 3)
 			So(r.Sequences[0].Start, ShouldEqual, 0)
 			So(r.Sequences[0].End, ShouldEqual, 1)

--- a/src/ui/help-ui.go
+++ b/src/ui/help-ui.go
@@ -29,6 +29,12 @@ Results will show up in the [::b]info window[::-] on the right.
 You can scroll through the results with the arrow keys up and down, or <ctrl-k> and <ctrl-j>, or <ctrl-n> and <ctrl-p>.
 
 If you can't see everything in the [::b]info window[::-], you can scroll it with the page up/page down keys, or press Enter to focus on it and get more precise scrolling.
+
+[::b]Special Search Syntax[::-]
+
+In addition to text search as described above, there are some special patterns you can use to futher narrow your query. Separate these blocks from the rest of your query with a space.
+
+- [::b]Challenge Rating[::-]: Use [::b]cr(number)[::-] (eg: [::b]cr10[::-]) to narrow down to monsters with a CR matching the provided number.
 `),
 
 	HelpPageEntity: trim(`


### PR DESCRIPTION
This PR introduces the concept of a Query, which can be extracted from the query string. A Query is used as a primary filter against which the normal text search works---if any Query is present, ALL Queries MUST match, for the Entity to be accepted into the result set.

Included in this PR is a single Query type, the `ChallengeRatingQuery`. The syntax for this query is `cr(number)`, eg `cr10`. It matches monsters whose CR exactly equal the query.

In future, most queries will likely have the syntax `[what]:[how]`, eg `cr:10`. We could even consider something like `cr:>=10`. This would be much simpler to build in a generic way, frankly, but I do like the simplicity of the syntax here for this specific case, and will likely continue to support it, so sticking with it for now.
