### PR TITLE
fix(help): correct ctrl-j shortcut in CLI usage

### DIFF
--- a/main.go
+++ b/main.go
@@ -21,7 +21,7 @@ func parseOptions() *options {
 Usage: beholder
 
 That's it! Just run the command and start typing to search for whatever
-you're curious about. Use <ctrl-k> and <ctrl-k> to scroll through
+you're curious about. Use <ctrl-k> and <ctrl-j> to scroll through
 results. If the information doesn't fit entirely in the info pane, you
 can focus on it by pressing <enter>.
 


### PR DESCRIPTION
## What changed
- Fix CLI help text typo in usage output
- Replace duplicated `<ctrl-k>` with correct `<ctrl-j>` for downward navigation

## Why
Issue #23 reports the shortcut hint currently says `<ctrl-k>` for both directions, which is confusing for new users.

Closes #23